### PR TITLE
Fixing SerializationException while parsing unknown proprties

### DIFF
--- a/shared/src/commonMain/kotlin/com/example/musicapp_kmp/network/SpotifyApiImpl.kt
+++ b/shared/src/commonMain/kotlin/com/example/musicapp_kmp/network/SpotifyApiImpl.kt
@@ -58,7 +58,7 @@ class SpotifyApiImpl : SpotifyApi {
             socketTimeoutMillis = timeout
         }
         install(ContentNegotiation) {
-            json()
+            json(kotlinx.serialization.json.Json { isLenient = true; ignoreUnknownKeys = true })
         }
     }
 


### PR DESCRIPTION
- Adding Ktor json "isLenient = true" to remove JSON specification restriction (RFC-4627) and makes parser more liberal to the malformed input.
- Adding Ktor json "ignoreUnknownKeys = true" to specify whether encounters of unknown properties in the input JSON should be ignored instead of throwing SerializationException.