### PR TITLE
Added pause button to player view to improve user experience

### DIFF
--- a/shared/src/commonMain/composeResources/drawable/baseline_pause_24.xml
+++ b/shared/src/commonMain/composeResources/drawable/baseline_pause_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#FFFACD" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="#FACD66" android:pathData="M6,19h4L10,5L6,5v14zM14,5v14h4L18,5h-4z"/>
+    
+</vector>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -11,4 +11,5 @@
     <string name="forward">Forward</string>
     <string name="back">Back</string>
     <string name="play">Play</string>
+    <string name="pause">Pause</string>
 </resources>

--- a/shared/src/commonMain/kotlin/musicapp/playerview/PlayerView.kt
+++ b/shared/src/commonMain/kotlin/musicapp/playerview/PlayerView.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -41,13 +42,14 @@ import musicapp.player.MediaPlayerController
 import musicapp.player.MediaPlayerListener
 import musicapp_kmp.shared.generated.resources.Res
 import musicapp_kmp.shared.generated.resources.back
+import musicapp_kmp.shared.generated.resources.baseline_pause_24
 import musicapp_kmp.shared.generated.resources.forward
+import musicapp_kmp.shared.generated.resources.pause
 import musicapp_kmp.shared.generated.resources.play
-import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
 
-@OptIn(ExperimentalResourceApi::class)
 @Composable
 internal fun PlayerView(playerComponent: PlayerComponent) {
     val state = playerComponent.viewModel.playerViewState.collectAsState()
@@ -78,7 +80,9 @@ internal fun PlayerView(playerComponent: PlayerComponent) {
     Box(
         modifier = Modifier.fillMaxWidth().background(Color(0xCC101010))
             .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 16.dp)
-            .clickable(indication = null, interactionSource = remember { MutableInteractionSource() }) { }
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }) { }
     ) {
         Row(modifier = Modifier.fillMaxWidth()) {
             val painter = rememberAsyncImagePainter(
@@ -133,19 +137,9 @@ internal fun PlayerView(playerComponent: PlayerComponent) {
                             }
                         })
                 )
-                Icon(
-                    imageVector = Icons.Filled.PlayArrow,
-                    tint = Color(0xFFFACD66),
-                    contentDescription = stringResource(Res.string.play),
+                PlayPauseButton(
                     modifier = Modifier.padding(end = 8.dp).size(32.dp)
-                        .align(Alignment.CenterVertically)
-                        .clickable(onClick = {
-                            if (mediaPlayerController.isPlaying()) {
-                                mediaPlayerController.pause()
-                            } else {
-                                mediaPlayerController.start()
-                            }
-                        })
+                        .align(Alignment.CenterVertically), mediaPlayerController
                 )
                 Icon(
                     imageVector = Icons.Default.ArrowForward,
@@ -162,6 +156,36 @@ internal fun PlayerView(playerComponent: PlayerComponent) {
             }
         }
     }
+}
+
+@Composable
+fun PlayPauseButton(modifier: Modifier, mediaPlayerController: MediaPlayerController) {
+    val isPlaying = rememberSaveable { mutableStateOf(true) }
+    if (isPlaying.value)
+        Icon(
+            painter = painterResource(Res.drawable.baseline_pause_24),
+            tint = Color(0xFFFACD66),
+            contentDescription = stringResource(Res.string.pause),
+            modifier = modifier
+                .clickable(onClick = {
+                    if (mediaPlayerController.isPlaying()) {
+                        mediaPlayerController.pause()
+                        isPlaying.value = false
+                    }
+                })
+        ) else
+        Icon(
+            imageVector = Icons.Filled.PlayArrow,
+            tint = Color(0xFFFACD66),
+            contentDescription = stringResource(Res.string.play),
+            modifier = modifier
+                .clickable(onClick = {
+                    if (mediaPlayerController.isPlaying().not()) {
+                        mediaPlayerController.start()
+                        isPlaying.value = true
+                    }
+                })
+        )
 }
 
 private fun playTrack(


### PR DESCRIPTION
## Fixes #16

## Description
Hi @SEAbdulbasit and @SubhrajyotiSen
As per the reported issue, only a play button is visible to the user all the time whether the track is played or paused. I have added a vector drawable to show the pause button on the UI. Currently, the pause icon is not available in the collection of material icons so, I had to add a separate vector drawable for the pause button. As per the attached videos, we can see that it shows play and pause icons according to the state of the selected track and will eventually improve user experience.

## Demo Video

| Android | iOS    |
| :---:   | :---: |
| <video src="https://github.com/user-attachments/assets/74e0f576-2317-4737-924b-e5c697b26389"/> | <video src="https://github.com/user-attachments/assets/d37a1e21-f77e-474d-90d8-21760289e420"/>  |