### PR TITLE
- Fix: Set mainClass to "DesktopAppKt" in desktopApp build.gradle.kts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ git clone https://github.com/SEAbdulbasit/MusicApp-KMP.git
   generate a new token from the [Spotify Developer Dashboard](https://developer.spotify.com/console/get-album-tracks/).
 - Run the app on your desired platform.
   There are a few known issues with the Music Player app using Compose Multiplatform UI:
+- Run on Desktop
+  ```
+  ./gradlew desktopApp:run
+  ```
+  - Run on Web
+  ```
+  ./gradlew jsBrowserDevelopmentRun
+  ```
 
 ## Known Issues
 

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
 
 compose.desktop {
     application {
-        mainClass = "main"
+        mainClass = "DesktopAppKt"
     }
 }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.konan.target.Family
 
 plugins {
@@ -12,6 +13,9 @@ plugins {
 kotlin {
     androidTarget {
         compilations.all {
+        }
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_1_8)
         }
     }
 


### PR DESCRIPTION
- Fix: Set mainClass to "DesktopAppKt" in desktopApp build.gradle.kts
- Chore: Set JVM target to 1.8 for Android in shared build.gradle.kts
- Docs: Added command to run desktop/web app in README.md